### PR TITLE
修复 Swoole WebSocket 关闭后连接状态仍为 true

### DIFF
--- a/src/YurunHttp/WebSocket/Swoole.php
+++ b/src/YurunHttp/WebSocket/Swoole.php
@@ -118,7 +118,7 @@ class Swoole implements IWebSocketClient
     public function close()
     {
         $this->handler->close();
-        $this->connected = true;
+        $this->connected = false;
     }
 
     /**

--- a/tests/unit/WebSocketTest/WebSocketTest.php
+++ b/tests/unit/WebSocketTest/WebSocketTest.php
@@ -30,6 +30,8 @@ class WebSocketTest extends BaseTest
             $recv = $client->recv();
             $this->assertEquals('test:' . $time, $recv);
             $client->close();
+            // 关闭后 isConnected() 必须返回 false（issue #32）
+            $this->assertFalse($client->isConnected());
         });
     }
 
@@ -53,6 +55,7 @@ class WebSocketTest extends BaseTest
             $recv = $client->recv();
             $this->assertEquals('test:' . $time, $recv);
             $client->close();
+            $this->assertFalse($client->isConnected());
         });
     }
 


### PR DESCRIPTION
修复：#32

`isConnected()` 无法判断是否被服务器关闭连接
参考：https://wiki.swoole.com/zh-cn/#/coroutine_client/client?id=isconnected